### PR TITLE
Fixing broken anchor to Rules in the IntelliJ page

### DIFF
--- a/intellij/index.html
+++ b/intellij/index.html
@@ -199,7 +199,7 @@
                             This action has a configurable key binding (Control + Shift + S by default) and is also available in the SonarLint console and editor popup menu.
                         </li>
                         <li>
-                            <span class="bold">How to configure rules?</span> - Check the <a href="#Connected">"Connected Mode"</a> section. When not connected to a SonarQube server, <a href="rules/index/html">these</a> are the rules used by SonarLint.
+                            <span class="bold">How to configure rules?</span> - Check the <a href="#Connected">"Connected Mode"</a> section. When not connected to a SonarQube server, <a href="rules/index.html">these</a> are the rules used by SonarLint.
                         </li>
                         <li>
                             <span class="bold">Can I change the highlighting of issues?</span> - Yes, in Settings -> Editor -> Colors & Fonts -> SonarLint.


### PR DESCRIPTION
This is a very small change on the anchor, will leave this PR open if anyone wants to review and merge, thank you.
