### PR TITLE
IntelliJ FAQ ID updates

### DIFF
--- a/intellij/index.html
+++ b/intellij/index.html
@@ -225,7 +225,7 @@
                             <span class="bold">How to enable SonarLint?</span> - SonarLint is enabled by default.
                         </li>
                         <li>
-                            <span class="bold">Which languages are supported?</span> - Java, JavaScript, PHP and Python. With the <a href="#Connected">Connected Mode</a>, it adds: ABAP, COBOL, PL/SQL, Swift.
+                            <span class="bold"  id="which_languages_supported">Which languages are supported?</span> - Java, JavaScript, PHP and Python. With the <a href="#Connected">Connected Mode</a>, it adds: ABAP, COBOL, PL/SQL, Swift.
                         </li>
                         <li>
                             <span class="bold">How can I connect SonarLint to my SonarQube server?</span> - Check the <a href="#Connected">Connected Mode</a> section. This allows to configure rules and settings, but there is no tracking of issues yet.
@@ -240,12 +240,12 @@
                             </div>
                         </li>
                         <li>
-                         <span class="bold">In Connected Mode, will all plugins installed on SonarQube be executed in SonarLint?</span>
+                         <span class="bold" id="connect_supported_plugins">In Connected Mode, will all plugins installed on SonarQube be executed in SonarLint?</span>
                          - SonarLint supports the SonarSource Analyzers (SonarJava, SonarJS, ...) and also custom rules extending these SonarSource analyzers.<br/>
                          We don't plan to support plugins running third-party analyzers (like PMD, Android Lint, JSLint...). Most of the time those analyzers already have dedicated IDE integration.
                         </li>
                         <li>
-                            <span class="bold">How to start SonarLint analysis?</span> - By default, SonarLint analysis are triggered automatically when working on the code (this behaviour can be disabled in the configuration). It can also be launched manually with the action "Analyze this file with SonarLint" (Control+Shift+A).
+                            <span class="bold" id="howto_start_analysis">How to start SonarLint analysis?</span> - By default, SonarLint analysis are triggered automatically when working on the code (this behaviour can be disabled in the configuration). It can also be launched manually with the action "Analyze this file with SonarLint" (Control+Shift+A).
                             This action has a configurable key binding (Control + Shift + S by default) and is also available in the SonarLint console and editor popup menu.
                         </li>
                         <li>
@@ -257,7 +257,7 @@
                         	<img class="center" src="resources/images/edit_highlight.png"/>
                         </li>
                         <li>
-                            <span class="bold">How to exclude files from the analysis?</span> - SonarLint analysis will run on every source file but only Java, JavaScript and PHP
+                            <span class="bold" id="howto_exclude_files">How to exclude files from the analysis?</span> - SonarLint analysis will run on every source file but only Java, JavaScript and PHP
                             files are processed. Advanced users can configure some properties (File -> Settings -> SonarLint) like <tt>sonar.exclusions</tt>.
                         </li>
                         <li>


### PR DESCRIPTION
The ID's already present in the Eclipse FAQ help link precisely to the supported languages sections. In order to support the same links with the IntelliJ FAQ, I propose the introduction of these IDs.

In general it might be a good idea to keep the 3 pages (Visual Studio included) as close as possible, this commit was partly motivated by this.