### PR TITLE
Add scripts to merge rules from different analyzers.

### DIFF
--- a/build/GenerateCppJsRulesDescription.ps1
+++ b/build/GenerateCppJsRulesDescription.ps1
@@ -1,15 +1,20 @@
 param
 (
-    [Parameter(Mandatory = $true, HelpMessage = "target path to store the rules description")]
+    [Parameter(Mandatory = $true,
+     HelpMessage = "target path to store the rules description")]
     [ValidateScript({Test-Path $_})]
     [string]
     $targetFolder,
 
-    [Parameter(Mandatory = $true, HelpMessage = "path to rule extractor (from sonarlint-core). For example 'c:\src\sonarlint-rule-extractor-2.18-SNAPSHOT-jar-with-dependencies.jar' ")]
+    [Parameter(Mandatory = $true,
+        HelpMessage = "path to rule extractor (from sonarlint-core). " +
+          "For example 'c:\src\sonarlint-rule-extractor-2.18-SNAPSHOT-jar-with-dependencies.jar' ")]
     [ValidateScript({Test-Path $_})]
     [string]
     $ruleExtractor
 )
+
+$ErrorActionPreference = "Stop"
 
 function FindDaemonVersion($fileText)
 {
@@ -18,19 +23,19 @@ function FindDaemonVersion($fileText)
     $versionGroup = $versionRegex.Match($fileText).Groups["version"]
     if (!$versionGroup.Success)
     {
-        Write-Error "todo"
+        throw "FindDaemonVersion: failed to find the version"
     }
-    $version = $versionGroup.Value
-    $version
+
+    return $versionGroup.Value
 }
 
-function GetFileContent($url)
+function GetUrlContent($url)
 {
     $response = Invoke-WebRequest -Uri $url -Method "GET" -UseBasicParsing
     if ($response.StatusCode -ne 200)
     {
         $code = $response.StatusCode
-        Write-Error "unexpected http code: $code"
+        throw "unexpected http code: $code"
     }
 
     return $response.Content
@@ -39,27 +44,25 @@ function GetFileContent($url)
 function DownloadFile($url, $targetPath)
 {
     (New-Object System.Net.WebClient).DownloadFile($url, $targetPath)
-
-    # $text = GetFileContent -url $url
-    # Set-Content -Path $targetPath -Value $text
 }
 
-
-$ruleExtractor = "C:\src\sonarlint-core\rule-extractor\target\sonarlint-rule-extractor-2.18-SNAPSHOT-jar-with-dependencies.jar"
-
-
-$daemonText = GetFileContent -url "https://raw.githubusercontent.com/SonarSource/sonarlint-visualstudio/master/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs"
+$daemonText = GetUrlContent `
+    -url "https://raw.githubusercontent.com/SonarSource/sonarlint-visualstudio/master/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs"
 $daemonVersion = FindDaemonVersion -fileText $daemonText
 
-$pomXmlText = GetFileContent -url "https://raw.githubusercontent.com/SonarSource/sonarlint-core/$daemonVersion/daemon/pom.xml"
+$pomXmlText = GetUrlContent `
+    -url "https://raw.githubusercontent.com/SonarSource/sonarlint-core/$daemonVersion/daemon/pom.xml"
 $pomXml = [xml]$pomXmlText
 $sonarJsVersion  = $pomXml["project"]["properties"]["sonar.javascript.version"].'#text'
 $sonarCppVersion = $pomXml["project"]["properties"]["sonar.cfamily.version"].'#text'
     
-$targetFolder = $PSScriptRoot
+DownloadFile `
+    -url "https://sonarsource.bintray.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-$sonarJsVersion.jar" `
+    "$targetFolder\jsplugin.jar"
 
-DownloadFile -url "https://sonarsource.bintray.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-$sonarJsVersion.jar" "$targetFolder\jsplugin.jar"
-DownloadFile -url "https://sonarsource.bintray.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-$sonarCppVersion.jar" "$targetFolder\cplugin.jar"
+DownloadFile `
+    -url "https://sonarsource.bintray.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-$sonarCppVersion.jar" `
+    "$targetFolder\cplugin.jar"
 
-java -jar $ruleExtractor dummyversion-js "$targetFolder\jsplugin.jar" > "jsplugin.rule.json"
-java -jar $ruleExtractor dummyversion-c "$targetFolder\cplugin.jar" > "cplugin.rule.json"
+java -jar $ruleExtractor dummyversion-js "$targetFolder\jsplugin.jar" > "$targetFolder\jsplugin.rule.json"
+java -jar $ruleExtractor dummyversion-c  "$targetFolder\cplugin.jar"  > "$targetFolder\cplugin.rule.json"

--- a/build/GenerateCppJsRulesDescription.ps1
+++ b/build/GenerateCppJsRulesDescription.ps1
@@ -1,0 +1,65 @@
+param
+(
+    [Parameter(Mandatory = $true, HelpMessage = "target path to store the rules description")]
+    [ValidateScript({Test-Path $_})]
+    [string]
+    $targetFolder,
+
+    [Parameter(Mandatory = $true, HelpMessage = "path to rule extractor (from sonarlint-core). For example 'c:\src\sonarlint-rule-extractor-2.18-SNAPSHOT-jar-with-dependencies.jar' ")]
+    [ValidateScript({Test-Path $_})]
+    [string]
+    $ruleExtractor
+)
+
+function FindDaemonVersion($fileText)
+{
+    $versionRegex = [regex]'daemonVersion\s*=\s*\"(?<version>[0-9\.]+)"\s*;'
+
+    $versionGroup = $versionRegex.Match($fileText).Groups["version"]
+    if (!$versionGroup.Success)
+    {
+        Write-Error "todo"
+    }
+    $version = $versionGroup.Value
+    $version
+}
+
+function GetFileContent($url)
+{
+    $response = Invoke-WebRequest -Uri $url -Method "GET" -UseBasicParsing
+    if ($response.StatusCode -ne 200)
+    {
+        $code = $response.StatusCode
+        Write-Error "unexpected http code: $code"
+    }
+
+    return $response.Content
+}
+
+function DownloadFile($url, $targetPath)
+{
+    (New-Object System.Net.WebClient).DownloadFile($url, $targetPath)
+
+    # $text = GetFileContent -url $url
+    # Set-Content -Path $targetPath -Value $text
+}
+
+
+$ruleExtractor = "C:\src\sonarlint-core\rule-extractor\target\sonarlint-rule-extractor-2.18-SNAPSHOT-jar-with-dependencies.jar"
+
+
+$daemonText = GetFileContent -url "https://raw.githubusercontent.com/SonarSource/sonarlint-visualstudio/master/src/Integration.Vsix/SonarLintDaemon/SonarLintDaemon.cs"
+$daemonVersion = FindDaemonVersion -fileText $daemonText
+
+$pomXmlText = GetFileContent -url "https://raw.githubusercontent.com/SonarSource/sonarlint-core/$daemonVersion/daemon/pom.xml"
+$pomXml = [xml]$pomXmlText
+$sonarJsVersion  = $pomXml["project"]["properties"]["sonar.javascript.version"].'#text'
+$sonarCppVersion = $pomXml["project"]["properties"]["sonar.cfamily.version"].'#text'
+    
+$targetFolder = $PSScriptRoot
+
+DownloadFile -url "https://sonarsource.bintray.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-$sonarJsVersion.jar" "$targetFolder\jsplugin.jar"
+DownloadFile -url "https://sonarsource.bintray.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-$sonarCppVersion.jar" "$targetFolder\cplugin.jar"
+
+java -jar $ruleExtractor dummyversion-js "$targetFolder\jsplugin.jar" > "jsplugin.rule.json"
+java -jar $ruleExtractor dummyversion-c "$targetFolder\cplugin.jar" > "cplugin.rule.json"

--- a/build/MergeRules.ps1
+++ b/build/MergeRules.ps1
@@ -1,0 +1,67 @@
+param
+(
+    [Parameter(Mandatory = $true, HelpMessage = "full path to json rules file")]
+    [ValidateScript({Test-Path $_})]
+    [string]
+    $mainFilePath,
+
+    [Parameter(Mandatory = $true, HelpMessage = "full path to json rules file to be merged")]
+    [ValidateScript({Test-Path $_})]
+    [string]
+    $filesToMergePath,
+
+    [Parameter(Mandatory = $true, HelpMessage = "path to the result - merged file")]
+    [string]
+    $targetFilePath
+)
+
+function DecodeUtfCharacters($text)
+{
+    $charRegex = [regex]'\\u[a-zA-Z0-9]{4}'
+    $matches = $charRegex.Matches($text)
+
+    if (!$matches)
+    {
+        return $text
+    }
+
+    $utfToReplace = $matches | Select-Object -ExpandProperty Value -Unique
+
+    $result = $text
+    foreach ($u in $utfToReplace)
+    {
+        $repl = [regex]::Unescape($u)
+        $result = $result.Replace($u, $repl)
+    }
+
+    $result
+}
+
+
+$mainFileText = (Get-Content -Path $mainFilePath -Encoding UTF8) -Join "`n"
+$mainFileJson = ConvertFrom-Json -InputObject $mainFileText
+
+$fileToMergeText = (Get-Content -Path $fileToMergePath -Encoding UTF8) -Join "`n"
+$fileToMergeJson = ConvertFrom-Json -InputObject $fileToMergeText
+
+$result = $mainFileJson
+
+foreach ($ruleToMerge in $fileToMergeJson.rules)
+{
+     $existingRule = $result.rules | where-object { $_.key -eq $ruleToMerge.key }
+
+     if ($existingRule)
+     {
+         $existingRule.implementations += $ruleToMerge.implementations
+     }
+     else
+     {
+         $result.rules += $ruleToMerge
+     }
+}
+
+$resultJson = ConvertTo-Json -Depth 5 $result
+$unsescapedResultJson = DecodeUtfCharacters -text $resultJson
+
+Set-Content $targetFilePath -Value $unsescapedResultJson -Encoding UTF8
+    

--- a/build/MergeRules.ps1
+++ b/build/MergeRules.ps1
@@ -83,4 +83,3 @@ foreach ($ruleToMerge in $rulesToMerge.rules)
 
 $escapedJson = ToEscapedJson -psObject $mergedRules
 Set-Content $targetFilePath -Value $escapedJson
-    


### PR DESCRIPTION
GenerateCppJsRulesDescription.ps1 fetches the rules for C family and Javascript that are embedded in current version sonarlint on master branch.
MergeRules.ps1 merges two rule sets into one. It's a proper merge that allows for tabbed view on the webpage.